### PR TITLE
Trim string values in ObjectWrapper methods

### DIFF
--- a/src/ObjectWrapper.php
+++ b/src/ObjectWrapper.php
@@ -150,7 +150,7 @@ class ObjectWrapper implements ArrayAccess, IteratorAggregate
 
     public function getRequiredString(string $key): string
     {
-        return $this->getRequiredOfType($key, 'string');
+        return trim($this->getRequiredOfType($key, 'string'));
     }
 
     /**
@@ -158,10 +158,13 @@ class ObjectWrapper implements ArrayAccess, IteratorAggregate
      * @param string|null $default
      * @return string|null
      */
-    public function getString(string $key, string $default = null)
+    public function getString(string $key, string $default = null): ?string
     {
-        return $this->getOfType($key, 'string', $default);
+        $value = $this->getOfType($key, 'string', $default);
+
+        return $value === null ? $value : trim($value);
     }
+
 
     public function getArray(string $key, array $default = []): array
     {

--- a/src/ObjectWrapper.php
+++ b/src/ObjectWrapper.php
@@ -165,7 +165,6 @@ class ObjectWrapper implements ArrayAccess, IteratorAggregate
         return $value === null ? $value : trim($value);
     }
 
-
     public function getArray(string $key, array $default = []): array
     {
         return $this->getOfType($key, 'array', $default);

--- a/tests/ObjectWrapperTest.php
+++ b/tests/ObjectWrapperTest.php
@@ -132,8 +132,9 @@ class ObjectWrapperTest extends TestCase
 
     public function testGetRequiredString()
     {
-        $object = new ObjectWrapper((object)['a' => 'string', 'b' => 123]);
+        $object = new ObjectWrapper((object)['a' => 'string', 'b' => 123, 'c' => '  whitespace  ']);
         $this->assertSame('string', $object->getRequiredString('a'));
+        $this->assertSame('whitespace', $object->getRequiredString('c'));
         $this->expectException(InvalidItemTypeException::class);
         $object->getRequiredString('b');
     }
@@ -182,10 +183,11 @@ class ObjectWrapperTest extends TestCase
 
     public function testGetString()
     {
-        $object = new ObjectWrapper((object)['a' => 'string', 'b' => 123]);
+        $object = new ObjectWrapper((object)['a' => 'string', 'b' => 123, 'c' => '  whitespace  ']);
         $this->assertSame('string', $object->getString('a'));
-        $this->assertNull($object->getString('c'));
-        $this->assertSame('default', $object->getString('c', 'default'));
+        $this->assertSame('whitespace', $object->getRequiredString('c'));
+        $this->assertNull($object->getString('d'));
+        $this->assertSame('default', $object->getString('d', 'default'));
         $this->expectException(InvalidItemTypeException::class);
         $object->getString('b');
     }


### PR DESCRIPTION
Added `trim` to `getRequiredString` and `getString` methods in `ObjectWrapper`. This ensures that leading and trailing whitespaces are removed from string values. Updated tests to cover this new behavior.