### PR TITLE
Suppress Symfony deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.4.1
+### Fixed
+- Suppress Symfony deprecations
 
 ## 0.4.0
 

--- a/src/ObjectWrapper.php
+++ b/src/ObjectWrapper.php
@@ -59,6 +59,10 @@ class ObjectWrapper implements ArrayAccess, IteratorAggregate
         return isset($this->data->$key);
     }
 
+    /**
+     * @param mixed $key
+     * @return mixed
+     */
     #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {


### PR DESCRIPTION
Suppress Symfony deprecations like the following:
```
User Deprecated: Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "Paysera\Component\ObjectWrapper\ObjectWrapper" now to avoid errors or add an explicit @return annotation to suppress this message.
```